### PR TITLE
BUGFIX: Able to delete recipes again

### DIFF
--- a/controllers/recipes.js
+++ b/controllers/recipes.js
@@ -106,7 +106,7 @@ module.exports = {
       console.log("Ingredients: ", req.body.ingredients);
       console.log("Directions: ", req.body.directions);
       await Recipe.create({
-        name: req.body.name,
+        name: req.body.recipeName,
         image: result.secure_url,
         cloudinaryId: result.public_id,
         description: req.body.description,

--- a/controllers/recipes.js
+++ b/controllers/recipes.js
@@ -11,9 +11,9 @@ const NextSkipValue = (currentSkipValue) => {
 
 module.exports = {
   getProfile: async (req, res) => {
+    console.log("getProfile was invoked");
     const currentPage = "profile";
     console.log(currentPage);
-    console.log("getProfile was invoked");
     try {
       //since we have a session each request contains the logged in user's
       //info: req.user
@@ -51,6 +51,7 @@ module.exports = {
     }
   },
   getFeed: async (req, res) => {
+    console.log("getFeed was invoked");
     const currentPage = "feed";
     console.log(currentPage);
     try {
@@ -73,10 +74,9 @@ module.exports = {
     }
   },
   getRecipe: async (req, res) => {
+    console.log("getRecipe was invoked");
     const currentPage = "recipe";
-    console.log(currentPage);
     try {
-      console.log("getRecipe was invoked");
       console.log(req.params);
       const comment = await Comment.find({ postId: req.params.id });
       console.log("comment: ", comment);
@@ -92,6 +92,7 @@ module.exports = {
     }
   },
   createRecipe: async (req, res) => {
+    console.log("createRecipe was invoked");
     try {
       console.log(`attempting to submit recipe!`);
       // Upload image to cloudinary
@@ -123,6 +124,7 @@ module.exports = {
     }
   },
   favoriteRecipe: async (req, res) => {
+    console.log("favoriteRecipe was invoked");
     try {
       await Favorite.create({
         user: req.user.id,
@@ -135,8 +137,8 @@ module.exports = {
     }
   },
   likeRecipe: async (req, res) => {
+    console.log("likeRecipe was invoked");
     try {
-      console.log("Likes +1");
       await Recipe.findOneAndUpdate(
         { _id: req.params.id },
         {
@@ -149,7 +151,7 @@ module.exports = {
     }
   },
   searchRecipe: async (req, res) => {
-    console.log("🔎 The search button is working.");
+    console.log("searchRecipe was invoked");
     console.log("Query params:", req.query);
     const currentPage = "searchResults";
     try {
@@ -211,7 +213,7 @@ module.exports = {
     }
   },
   deleteRecipe: async (req, res) => {
-    console.log('   deleteRecipe was invoked')
+    console.log('deleteRecipe was invoked');
     try {
       const recipeDbId = req.params.id;
       console.log("   Finding recipe id: ", recipeDbId);

--- a/routes/recipe.js
+++ b/routes/recipe.js
@@ -15,7 +15,7 @@ router.post(
 
 router.post("/searchRecipes", recipesController.searchRecipe);
 
-router.put("/likeRecipe/:id", recipesController.likeRecipe);
+router.post("/likeRecipe/:id", recipesController.likeRecipe);
 
 router.post("/favoriteRecipe/:id", recipesController.favoriteRecipe);
 

--- a/views/partials/createRecipeModal.ejs
+++ b/views/partials/createRecipeModal.ejs
@@ -29,7 +29,7 @@
             </div>
 
             <div id="recipe-form" class="form-control">
-              <label for="ingredients[]" class="label">
+              <label for="ingredients" class="label">
                 <span class="label-text text-lg font-bold text-dark-slate-gray">Ingredients</span>
               </label>
               <input id="ingredients" name="ingredients[]"
@@ -40,7 +40,7 @@
               </button>
             </div>
             <div id="directions-form" class="form-control">
-              <label for="directions[]" class="form-label">
+              <label for="directions" class="form-label">
                 <span class="label-text text-lg font-bold text-dark-slate-gray">Directions</span>
               </label>
               <textarea class="textarea textarea-bordered my-2 h-22 bg-white text-dark-slate-gray" id="directions"
@@ -50,7 +50,7 @@
               </button>
             </div>
             <div class="mb-3">
-              <label for="imgUpload" class="form-label text-lg font-bold text-dark-slate-gray">Image</label>
+              <label for="imageUpload" class="form-label text-lg font-bold text-dark-slate-gray">Image</label>
               <input type="file" id="imageUpload" name="file"
                 class="form-control text-emerald-900 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-bold file:bg-violet-50 file:text-forest-green hover:file:bg-success-green hover:file:text-dark-slate-gray" />
             </div>

--- a/views/partials/createRecipeModal.ejs
+++ b/views/partials/createRecipeModal.ejs
@@ -13,10 +13,10 @@
 
           <form action="/recipe/createRecipe" enctype="multipart/form-data" method="POST">
             <div class="form-control w-full max-w-xs">
-              <label for="name" class="label">
+              <label for="recipe-name" class="label">
                 <span class="label-text text-lg font-bold text-dark-slate-gray">Recipe name</span>
               </label>
-              <input type="text" id="name" name="name" placeholder="recipe name"
+              <input type="text" id="recipe-name" name="recipeName" placeholder="recipe name"
                 class="input input-bordered w-full max-w-xs bg-white text-dark-slate-gray" />
             </div>
 

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -6,12 +6,12 @@
     <div class="navbar flex-wrap md:flex-nowrap bg-[#fffbbdf4]">
       <div class="md:navbar-start">
         <div class="dropdown">
-          <label tabindex="0" class="btn btn-ghost btn-circle">
+          <div tabindex="0" class="btn btn-ghost btn-circle">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 stroke-[#073D00]" fill="forest-green"
               viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 6h16M4 12h16M4 18h7" />
             </svg>
-          </label>
+          </div>
           <ul tabindex="0" class="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52">
             <li>
               <label for="my-modal-6" class="btn btn-outline btn-success flex-1">Create Recipe</label>

--- a/views/recipe.ejs
+++ b/views/recipe.ejs
@@ -30,7 +30,7 @@
             <%}%>
               <div class="flex mx-auto flex-row w-full mt-2">
                 <!-- Like a recipe button -->
-                <form class="flex flex-1" action="/recipe/likeRecipe/<%= recipe.id %>?_method=PUT" method="POST">
+                <form class="flex flex-1" action="/recipe/likeRecipe/<%= recipe.id %>" method="POST">
                   <button
                     class="btn bg-white btn-outline border-2 border-black shadow-solid-black btn-success fa fa-heart"
                     type="submit"></button>
@@ -46,7 +46,7 @@
                 </form>
                 <!-- Delete recipe button-->
                 <%if(recipe.user==user.id){ %>
-                  <form action="/recipe/deleteRecipe/<%= recipe.id %>?_method=DELETE" method="POST"
+                  <form action="/recipe/deleteRecipe/<%= recipe.id %>" method="POST"
                     class="flex justify-end flex-1">
                     <button
                       class="btn btn-outline btn-success bg-white fa fa-trash border-2 border-black shadow-solid-black"

--- a/views/recipe.ejs
+++ b/views/recipe.ejs
@@ -2,7 +2,7 @@
   <%- include('partials/navbar') %>
     <div class="">
 
-      <div class="flex flex-col w-4/6 mx-auto items-center">
+      <div class="flex flex-col sm:w-11/12 lg:w-4/6 mx-auto items-center">
         <!-- recipe name, image, and options-->
         <section class="flex flex-col w-full bg-[#b7ffbbf3] border-2 rounded border-black shadow-solid-black
         border-2 border-black py-6 px-4 w-3/4 mx-auto items-center">


### PR DESCRIPTION
At some point we lost the ability to delete recipes. This was discovered while doing some minor cleanup/refactors. We standardized the method definitions on the router file and removed the ?=_DELETE query param from the client-side.

Also:
- edit styles to make recipe card behave the same way as the navbar during media query re-sizings
- other minor console logging and cleanup changes